### PR TITLE
Mise à niveau Java 9 & +

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Reference: https://github.com/github/gitignore
+# Provides also OS gitignore files (Linux, macOS, Windows)
+
+.project
+
+######################
+######   Java   ######
+######################
+
 # Compiled class file
 *.class
 
@@ -21,3 +30,22 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+replay_pid*
+
+######################
+######   Maven  ######
+######################
+
+**/target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# geotortue
-GéoTortue de S. Tummarello
+# GéoTortue
+
+## 💡 Présentation 
+
+GéoTortue est un logiciel inspiré du langage LOGO pour découvrir les mathématiques et l’algorithmique.
+
+Le logiciel GéoTortue se distingue sur deux points&nbsp;:
+
+- il a été conçu pour tous, que ce soit en classe (de l’école élémentaire au lycée), chez-soi, entre amis, ...&nbsp;
+- il étend le champ d’application à la géométrie dans l’espace et à des géométries non-euclidiennes.
+
+## 🏁 Démarrage rapide
+
+### Pré-requis
+
+[GIT](https://git-scm.com/) et [Maven](https://maven.apache.org/) 3.6 & s. installés.
+
+### Sous linux
+
+Vérifier que Maven est disponible en version 3.6 ou plus.
+
+S'assurer que Java est disponible avec une version 9 & s.
+
+Cloner l'application puis la lancer avec Maven :
+
+
+``` bash
+mvn -v
+> Apache Maven 3.6.3
+> Maven home: /usr/share/maven
+> Java version: 17.0.8, vendor: GraalVM Community, runtime: /usr/lib/jvm/graalvm-community-openjdk-17.0.8+7.1
+> Default locale: en_US, platform encoding: UTF-8
+> OS name: "linux", version: "5.15.0-84-generic", arch: "amd64", family: "unix"
+
+git clone clone https://github.com/turiot/geotortue
+
+cd geotortue
+
+MAVEN_OPTS="--add-exports java.desktop/sun.swing=ALL-UNNAMED" mvn exec:java
+> [...]
+```
+
+> Ignorer le message au sujet du langage "en_US" non supporté.
+
+L'application s'ouvre, la tortue est prête à répondre à tous vos souhaits.
+
+## 🛠️ Développement
+
+Voir le [Guide pour contribuer](documentation/CONTRIBUTING.md).
+
+## 🛡️ Licence
+
+[GPL 3](./LICENSE)
+
+## 📜 Crédit
+
+- [GéoTortue](http://geotortue.free.fr/) a été créé et est maintenu par [Salvatore Tummarello](mailto:geotortue@free.fr).  
+Le logiciel doit beaucoup aux idées, suggestions et remarques enthousiastes de S. Petitjean, E. Adam, J.-F. Jamart et F. Clerc.
+
+- [GéoTortue](http://geotortue.free.fr/) a été développé au sein de l'[IREM Paris-Nord](https://www-irem.univ-paris13.fr) :
+
+  - [GéoTortue 3D : utilisation et exemples d’activités](https://www-irem.univ-paris13.fr/site_spip/spip.php?article352)
+  - [LOGO, ordinateurs et apprentissages](https://www-irem.univ-paris13.fr/site_spip/spip.php?article32)
+  - ...
+
+- R. Hartig a dessiné la [mascotte](src/main/resources/cfg/tortue-v4.png).

--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ MAVEN_OPTS="--add-exports java.desktop/sun.swing=ALL-UNNAMED" mvn exec:java
 > [...]
 ```
 
-> Ignorer le message au sujet du langage "en_US" non supporté.
-
 L'application s'ouvre, la tortue est prête à répondre à tous vos souhaits.
 
 ## 🛠️ Développement

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## Distribution
+
+Pour le moment, seuls un exécutable java (archive jar) et un exécutable pour Windows sont mis à disposition ici :
+
+S'assurer que la jdk installée est de version 9 ou supérieure.
+Puis construire l'archive exécutable jar et la lancer :
+
+``` bash
+java --version
+
+mvn -U clean package
+
+ls -Al target
+> total 8188
+> drwxrwsr-x 13 pierre developers    4096 Dec 16 15:50 classes
+> drwxrwsr-x  3 pierre developers    4096 Dec 16 15:50 generated-sources
+> -rw-rw-r--  1 pierre developers 4139520 Dec 16 15:51 geotortue-4.23.12.15.jar
+> -rwxrwxr-x  1 pierre developers 4227072 Dec 16 15:51 geotortue.exe
+> drwxrwsr-x  3 pierre developers    4096 Dec 16 15:50 maven-status
+
+java --add-exports java.desktop/sun.swing=ALL-UNNAMED -jar target/geotortue-4.23.12.15.jar
+
+```
+
+> L'exécutable Windows n'a pas été testé.
+
+Pour d'autres distributions voir [GéoTortue - Téléchargment](http://geotortue.free.fr/index.php?page=telechargement).
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,49 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>stummarello</groupId>
   <artifactId>geotortue</artifactId>
-  <version>4.19.4.5</version>
+  <version>4.23.12.15</version>
+
+  <name>GéoTortue</name>
+  <description>${project.name} est un logiciel inspiré du langage LOGO pour découvrir les mathématiques et l’algorithmique.</description>
+  <inceptionYear>2008</inceptionYear>
+
+  <organization>
+    <name>${project.name}</name>
+    <url>http://geotortue.free.fr/</url>
+  </organization>
 
   <properties>
+    <main.class>geotortue.GTLauncher</main.class>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>9</maven.compiler.target>
+    <maven.clean.version>3.3.2</maven.clean.version>
+    <maven.resources.version>3.3.1</maven.resources.version>
+    <maven.compiler.version>3.11.0</maven.compiler.version>
+    <maven.jar.version>3.3.0</maven.jar.version>
+    <exec.maven.version>3.1.1</exec.maven.version>
+    <launch4j.maven.version>2.4.1</launch4j.maven.version>
   </properties>
+
+  <licenses>
+    <license>
+      <name>GPL-3.0</name>
+      <url>https://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <repositories>
+    <repository>
+      <id>mvnrepository</id>
+      <name>mvnrepository</name>
+      <url>http://www.mvnrepository.com</url>
+    </repository>
+  </repositories>
 
   <build>
     <resources>
@@ -15,40 +51,64 @@
         <directory>src/main/resources</directory>
         <filtering>false</filtering>
       </resource>
-      <resource>
-        <directory>src/meta</directory>
-        <filtering>true</filtering>
-      </resource>
     </resources>   
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>${maven.clean.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>${maven.resources.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>${maven.compiler.version}</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
           <verbose>false</verbose>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <debug>true</debug>
+          <compilerArgs>
+            <arg>--add-exports=java.desktop/sun.swing=ALL-UNNAMED</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>${maven.jar.version}</version>
         <configuration>
           <archive>
-            <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
             <addMavenDescriptor>false</addMavenDescriptor>
+            <manifest>
+              <addDefaultEntries>false</addDefaultEntries>
+              <mainClass>${main.class}</mainClass>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Version>${project.version}</Implementation-Version>
+              <Sealed>true</Sealed>
+              <Class-Path>../</Class-Path>
+              <Add-Exports>java.desktop/sun.swing=ALL-UNNAMED</Add-Exports>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
       <plugin>
+		    <groupId>org.codehaus.mojo</groupId>
+		    <artifactId>exec-maven-plugin</artifactId>
+		    <version>${exec.maven.version}</version>
+		    <configuration>
+			    <mainClass>${main.class}</mainClass>
+ 		    </configuration>
+      </plugin>
+      <plugin>
           <groupId>com.akathist.maven.plugins.launch4j</groupId>
           <artifactId>launch4j-maven-plugin</artifactId>
-          <version>1.7.25</version>
+          <version>${launch4j.maven.version}</version>
           <executions>
               <execution>
                   <id>launch4j</id>
@@ -58,28 +118,29 @@
                   </goals>
                   <configuration>
                       <headerType>gui</headerType>
-                      <outfile>target/geotortue.exe</outfile>
-                      <jar>target/geotortue-${project.version}.jar</jar>
-                      <errTitle>Geotortue</errTitle>
+                      <outfile>target/${project.artifactId}.exe</outfile>
+                      <jar>target/${project.artifactId}-${project.version}.jar</jar>
+                      <errTitle>${project.name}</errTitle>
                       <icon>launch4j/icon.ico</icon>
                       <classPath>
-                          <mainClass>geotortue.GTLauncher</mainClass>
+                          <mainClass>${main.class}</mainClass>
                           <addDependencies>true</addDependencies>
                           <preCp>anything</preCp>
                       </classPath>
                       <jre>
+                          <path>$JAVA_HOME:$PATH</path>
                           <minVersion>1.7.0</minVersion>
                       </jre>
                       <versionInfo>
                           <fileVersion>1.2.3.4</fileVersion>
                           <txtFileVersion>${project.version}</txtFileVersion>
-                          <fileDescription>Application Geotortue</fileDescription>
-                          <copyright>GPL</copyright>
+                          <fileDescription>Application ${project.name}</fileDescription>
+                          <copyright>${project.licenses.license.name}</copyright>
                           <productVersion>${project.version}</productVersion>
                           <txtProductVersion>${project.version}</txtProductVersion>
-                          <productName>Geotortue</productName>
-                          <internalName>geotortue</internalName>
-                          <originalFilename>geotortue.exe</originalFilename>
+                          <productName>${project.name}</productName>
+                          <internalName>${project.artifactId}</internalName>
+                          <originalFilename>${project.artifactId}.exe</originalFilename>
                       </versionInfo>
                   </configuration>
               </execution>
@@ -87,5 +148,4 @@
       </plugin>      
     </plugins>
   </build>
-
 </project>

--- a/src/meta/META-INF/MANIFEST.MF
+++ b/src/meta/META-INF/MANIFEST.MF
@@ -1,5 +1,0 @@
-Manifest-Version: 1.0
-Implementation-Version: ${project.version}
-Main-Class: geotortue.GTLauncher
-Sealed: true
-Class-Path: ../


### PR DESCRIPTION
Objet : rendre exécutable en l'état GéoTortue sur toute JVM à partir de la version 9 avec l'arrivée des modules JPMS (Jigsaw).

/!\ Une JDK 9&s. est requise. Pas de profile Maven pour Java 7 & 8 /!\

/!\ L'exécutable Windows généré n'a pas été testé /!\

Mise à niveau :
- pom.xml : mise à jour des extensions
- pom.xml : ajouté exec:java pour lancement direct avec Maven
- doc : README complété avec démarrage rapide, crédit, licence, ...
- doc : ajout d'un embrion de CONTRIBUTING